### PR TITLE
Feature/backend

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -16,6 +16,7 @@
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
+        "moment-timezone": "^0.5.48",
         "morgan": "^1.10.0",
         "nodemon": "^3.1.9",
         "pg": "^8.14.1"
@@ -1576,6 +1577,25 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
+      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/morgan": {

--- a/server/package.json
+++ b/server/package.json
@@ -18,6 +18,7 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
+    "moment-timezone": "^0.5.48",
     "morgan": "^1.10.0",
     "nodemon": "^3.1.9",
     "pg": "^8.14.1"

--- a/server/server.mjs
+++ b/server/server.mjs
@@ -13,12 +13,10 @@ const app = express();
 const PORT = process.env.PORT || 5000;
 const NODE_ENV = process.env.NODE_ENV || 'development';
 
-app.use(cors({
-  origin: NODE_ENV === 'production' ? 'CLIENT_URL' : '*',
-}));
+app.use(cors());
 app.use(morgan(NODE_ENV === 'development' ? 'dev' : 'combined'));
 app.use(express.json());
-app.use(cookieParser()); // เพิ่ม middleware สำหรับจัดการ cookie
+app.use(cookieParser());
 
 const prisma = new PrismaClient();
 

--- a/server/server.mjs
+++ b/server/server.mjs
@@ -6,6 +6,7 @@ import connectToDatabase from './util/db.mjs';
 import { PrismaClient } from '@prisma/client';
 import cookieParser from 'cookie-parser';
 import authRoute from './util/routes/authRoute.mjs';
+import moment from 'moment-timezone';
 
 dotenv.config();
 
@@ -16,7 +17,12 @@ const NODE_ENV = process.env.NODE_ENV;
 app.use(cors({
   origin: NODE_ENV === 'production' ? 'CLIENT_URL' : '*',
 }));
-app.use(morgan(NODE_ENV === 'development' ? 'dev' : 'combined'));
+
+morgan.token('date', (req, res) => {
+  return moment().tz('Asia/Bangkok').format('YYYY-MM-DD HH:mm:ss'); // เวลาไทย
+});
+
+app.use(morgan(':remote-addr - :remote-user [:date] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"'));
 app.use(express.json());
 app.use(cookieParser()); // เพิ่ม middleware สำหรับจัดการ cookie
 

--- a/server/server.mjs
+++ b/server/server.mjs
@@ -10,13 +10,15 @@ import authRoute from './util/routes/authRoute.mjs';
 dotenv.config();
 
 const app = express();
-const PORT = process.env.PORT || 5000;
-const NODE_ENV = process.env.NODE_ENV || 'development';
+const PORT = process.env.PORT;
+const NODE_ENV = process.env.NODE_ENV;
 
-app.use(cors());
+app.use(cors({
+  origin: NODE_ENV === 'production' ? 'CLIENT_URL' : '*',
+}));
 app.use(morgan(NODE_ENV === 'development' ? 'dev' : 'combined'));
 app.use(express.json());
-app.use(cookieParser());
+app.use(cookieParser()); // เพิ่ม middleware สำหรับจัดการ cookie
 
 const prisma = new PrismaClient();
 


### PR DESCRIPTION
This pull request introduces the `moment-timezone` library to the project for handling timezone-specific date formatting and updates the server logging configuration to include timestamps in the "Asia/Bangkok" timezone. The changes also include updates to dependencies in `package.json` and `package-lock.json`.

### Dependency Updates:
* Added `moment-timezone` version `^0.5.48` as a new dependency in `package.json` and `package-lock.json`. This library is used for timezone-specific date and time handling. [[1]](diffhunk://#diff-da00458cdaeaea2314cb0e0101c85130593048072ada62de01727958c5d6ca37R21) [[2]](diffhunk://#diff-be330df323f72d45d073e311befe92984fad9846bb7e982261d702d805c14053R19)
* Updated `package-lock.json` to include metadata for `moment` and `moment-timezone`, including their resolved versions and integrity hashes.

### Server Configuration Changes:
* Imported `moment-timezone` in `server.mjs` to enable timezone-specific functionality.
* Modified the `morgan` logging configuration to include a custom token for timestamps formatted in the "Asia/Bangkok" timezone. This replaces the default logging format with a more detailed one that includes the timestamp.