### PR TITLE
test: fix cors

### DIFF
--- a/server/server.mjs
+++ b/server/server.mjs
@@ -16,7 +16,8 @@ const NODE_ENV = process.env.NODE_ENV;
 
 
 const allowedOrigins = [
-  process.env.CLIENT_URL, 
+  process.env.CLIENT_URL,,
+  'http://localhost:5173',
 ];
 
 app.use(cors({


### PR DESCRIPTION
This pull request modifies the `allowedOrigins` array in `server/server.mjs` to include a new origin for local development.

Key change:

* [`server/server.mjs`](diffhunk://#diff-0e3e63a039f20eefb8a5dc3300c92157092d2e071e5bfcbc94abe9086736ee1eL19-R20): Added `'http://localhost:5173'` to the `allowedOrigins` array to support CORS for a local development environment.