### PR TITLE
fix: user profile photos show at navbar after first login

### DIFF
--- a/client/src/components/ui/ResetPassword.jsx
+++ b/client/src/components/ui/ResetPassword.jsx
@@ -145,8 +145,7 @@ function ResetPassword() {
 
   return (
     <>
-      <form onSubmit={handleSubmit} className="bg-gray-50 p-6 rounded-lg shadow-sm flex flex-col gap-5">
-        {/* Pass type="password" to InputField */}
+      <form onSubmit={handleSubmit} className="bg-gray-100 p-6 rounded-lg shadow-sm flex flex-col gap-5">
         <InputField
           label="Current password"
           id="currentPassword"

--- a/client/src/components/ui/TiltedCard.jsx
+++ b/client/src/components/ui/TiltedCard.jsx
@@ -1,0 +1,136 @@
+import { useRef, useState } from "react";
+import { useMotionValue, useSpring } from "framer-motion";
+
+const springValues = {
+  damping: 30,
+  stiffness: 100,
+  mass: 2,
+};
+
+export default function TiltedCard({
+  imageSrc,
+  altText = "Tilted card image",
+  captionText = "",
+  containerHeight = "300px",
+  containerWidth = "100%",
+  imageHeight = "300px",
+  imageWidth = "300px",
+  scaleOnHover = 1.1,
+  rotateAmplitude = 14,
+  showMobileWarning = true,
+  showTooltip = true,
+  overlayContent = null,
+  displayOverlayContent = false,
+}) {
+  const ref = useRef(null);
+  const x = useMotionValue(0);
+  const y = useMotionValue(0);
+  const rotateX = useSpring(useMotionValue(0), springValues);
+  const rotateY = useSpring(useMotionValue(0), springValues);
+  const scale = useSpring(1, springValues);
+  const opacity = useSpring(0);
+  const rotateFigcaption = useSpring(0, {
+    stiffness: 350,
+    damping: 30,
+    mass: 1,
+  });
+
+  const [lastY, setLastY] = useState(0);
+
+  function handleMouse(e) {
+    if (!ref.current) return;
+
+    const rect = ref.current.getBoundingClientRect();
+    const offsetX = e.clientX - rect.left - rect.width / 2;
+    const offsetY = e.clientY - rect.top - rect.height / 2;
+
+    const rotationX = (offsetY / (rect.height / 2)) * -rotateAmplitude;
+    const rotationY = (offsetX / (rect.width / 2)) * rotateAmplitude;
+
+    rotateX.set(rotationX);
+    rotateY.set(rotationY);
+
+    x.set(e.clientX - rect.left);
+    y.set(e.clientY - rect.top);
+
+    const velocityY = offsetY - lastY;
+    rotateFigcaption.set(-velocityY * 0.6);
+    setLastY(offsetY);
+  }
+
+  function handleMouseEnter() {
+    scale.set(scaleOnHover);
+    opacity.set(1);
+  }
+
+  function handleMouseLeave() {
+    opacity.set(0);
+    scale.set(1);
+    rotateX.set(0);
+    rotateY.set(0);
+    rotateFigcaption.set(0);
+  }
+
+  return (
+    <figure
+      ref={ref}
+      className="relative w-full h-full [perspective:800px] flex flex-col items-center justify-center"
+      style={{
+        height: containerHeight,
+        width: containerWidth,
+      }}
+      onMouseMove={handleMouse}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      {showMobileWarning && (
+        <div className="absolute top-4 text-center text-sm block sm:hidden">
+          This effect is not optimized for mobile. Check on desktop.
+        </div>
+      )}
+
+      <motion.div
+        className="relative [transform-style:preserve-3d]"
+        style={{
+          width: imageWidth,
+          height: imageHeight,
+          rotateX,
+          rotateY,
+          scale,
+        }}
+      >
+        <motion.img
+          src={imageSrc}
+          alt={altText}
+          className="absolute top-0 left-0 object-cover rounded-[15px] will-change-transform [transform:translateZ(0)]"
+          style={{
+            width: imageWidth,
+            height: imageHeight,
+          }}
+        />
+
+        {displayOverlayContent && overlayContent && (
+          <motion.div
+            className="absolute top-0 left-0 z-[2] will-change-transform [transform:translateZ(30px)]"
+          >
+            {overlayContent}
+          </motion.div>
+        )}
+      </motion.div>
+
+      {showTooltip && (
+        <motion.figcaption
+          className="pointer-events-none absolute left-0 top-0 rounded-[4px] bg-white px-[10px] py-[4px] text-[10px] text-[#2d2d2d] opacity-0 z-[3] hidden sm:block"
+          style={{
+            x,
+            y,
+            opacity,
+            rotate: rotateFigcaption,
+          }}
+        >
+          {captionText}
+        </motion.figcaption>
+      )}
+    </figure>
+  );
+}

--- a/server/util/controllers/authController.mjs
+++ b/server/util/controllers/authController.mjs
@@ -78,8 +78,6 @@ const login = async (req, res) => {
       expiresIn: '1d',
     });
 
-
-
     const { password: _, ...userWithoutPassword } = user;
     res.status(200).json({
       message: 'Login successful.',
@@ -90,6 +88,7 @@ const login = async (req, res) => {
         username: userWithoutPassword.username,
         name: userWithoutPassword.name,
         role: userWithoutPassword.role,
+        profile_pic: userWithoutPassword.profile_pic,
       }
     });
 


### PR DESCRIPTION
This pull request introduces a new `TiltedCard` component with interactive 3D tilt effects, updates the `ResetPassword` form's styling, and adds a `profile_pic` field to the login response in the authentication controller. Below is a summary of the key changes:

### New Component Addition:
* Added a new `TiltedCard` component in `client/src/components/ui/TiltedCard.jsx`. This component uses `framer-motion` to create a 3D tilt effect with customizable properties such as hover scaling, rotation amplitude, and optional overlay content. It also includes a tooltip and a warning for mobile users.

### UI Updates:
* Updated the `ResetPassword` form in `client/src/components/ui/ResetPassword.jsx` to use a slightly lighter background color (`bg-gray-100` instead of `bg-gray-50`) for improved visual contrast.

### Backend Enhancements:
* Modified the `login` function in `server/util/controllers/authController.mjs` to include the `profile_pic` field in the response payload, allowing clients to access the user's profile picture after login.
* Removed unnecessary blank lines in the `login` function for cleaner code formatting.